### PR TITLE
Upgrade to Rust 1.56

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: rust:1.55.0
+    container: rust:1.56
     services:
       postgres:
         image: postgres:13.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "yarrbot"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "actix",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,8 +738,12 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
+ "bitflags",
  "byteorder",
  "diesel_derives",
+ "pq-sys",
+ "r2d2",
+ "uuid",
 ]
 
 [[package]]
@@ -1948,6 +1952,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pq-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+dependencies = [
+ "vcpkg",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2026,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.27",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -2475,6 +2499,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,16 +734,12 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba51ca66f57261fd17cadf8b73e4775cc307d0521d855de3f5de91a8f074e0e"
+checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
- "bitflags",
  "byteorder",
  "diesel_derives",
- "pq-sys",
- "r2d2",
- "uuid",
 ]
 
 [[package]]
@@ -1952,15 +1948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "pq-sys"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
-dependencies = [
- "vcpkg",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,17 +2013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.27",
-]
-
-[[package]]
-name = "r2d2"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
-dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -2499,15 +2475,6 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarrbot"
-version = "0.5.4"
-edition = "2018"
+version = "0.5.5"
+edition = "2021"
 
 [[bin]]
 name = "yarrbot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.55 as builder
+FROM rust:1.56 as builder
 
 WORKDIR /usr/src/myapp
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarrbot_common"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarrbot_db"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "1.4.8" }
+diesel = { version = "1.4.8", features = ["postgres", "r2d2", "uuidv07"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 diesel_migrations = "1.4.0"
 diesel-derive-enum = { version = "1", features = ["postgres"] }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diesel = { version = "1.4.4", features = ["postgres", "r2d2", "uuidv07"] }
-uuid = { version = "= 0.8.2", features = ["v4"] }
+diesel = { version = "1.4.8" }
+uuid = { version = "0.8.2", features = ["v4"] }
 diesel_migrations = "1.4.0"
 diesel-derive-enum = { version = "1", features = ["postgres"] }
 strum = "0.21"

--- a/crates/matrix_client/Cargo.toml
+++ b/crates/matrix_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarrbot_matrix_client"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/webhook_api/Cargo.toml
+++ b/crates/webhook_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yarrbot_webhook_api"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Upgrades Yarrbot to Rust 1.56 and Edition 2021.