### PR TITLE
Allow setting a custom UID and/or GID for the user in the container; smaller base image; minor fix to resolve a warning.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,23 +9,26 @@ RUN apt-get update && apt-get install -y cmake make libpq-dev
 RUN cargo build --release
 RUN strip ./target/release/yarrbot
 
-FROM ubuntu:latest
+FROM debian:buster-slim
 
 RUN addgroup --system --gid 1000 yarrbot && \
     adduser --system --no-create-home --shell /bin/false --uid 1000 --gid 1000 yarrbot && \
     apt-get update && \
-    apt-get install -y ca-certificates libpq5 && \
+    apt-get install -y ca-certificates libpq5 gosu && \
     mkdir /app /data && \
     chown -R yarrbot:yarrbot /app && \
     chown yarrbot:yarrbot /data && \
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
-COPY --chown=yarrbot:yarrbot --from=builder /usr/src/myapp/target/release/yarrbot /app/yarrbot
+COPY --chown=yarrbot:yarrbot ./docker/scripts/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+COPY --chown=yarrbot:yarrbot --from=builder /usr/src/myapp/target/release/yarrbot /usr/bin/yarrbot
 
 VOLUME ["/data"]
 
-USER yarrbot
 ENV YARRBOT_STORAGE_DIR=/data
 ENV YARRBOT_WEB_PORT=8080
+ENV PUID=1000
+ENV PGID=1000
 EXPOSE 8080
-ENTRYPOINT ["/app/yarrbot"]
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+CMD ["yarrbot"]

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ to spam you with useless notifications.
 
 #### Quick Start
 
-Starting Yarrbot using a container image, binding to port `8081` on the host and mounting a managed volume to `/data`
-in the container:
+Starting Yarrbot using a container image, binding to port `8081` on the host, mounting a managed volume to `/data`
+in the container, and setting the UID/GID of the user and group in the container both to `1000`:
 
 ```
 podman run -d \
@@ -58,6 +58,8 @@ podman run -d \
     --secret yarrbot-matrix-pass \
     -p 8081:8080 \
     -v yarrbot-storage:/data \
+    -e PUID=1000 \
+    -e PGID=1000 \
     -e YARRBOT_DATABASE_URL_FILE=/run/secrets/yarrbot-db-url \
     -e YARRBOT_MATRIX_USERNAME=yarrbot \
     -e YARRBOT_MATRIX_PASSWORD_FILE=/run/secrets/yarrbot-matrix-pass \
@@ -114,6 +116,8 @@ the file system located at the path defined by the environment variable. See the
   logged, but only "warning" or higher messages from Yarrbot's dependencies being logged. The default is recommended for
   most users. While Yarrbot uses the [`tracing` crate](https://tracing-rs.netlify.app/tracing/) for log functionality,
   the `tracing` crate uses the [`env_logger` crate's log level controls](https://docs.rs/env_logger/0.9.0/env_logger/#enabling-logging).
+* `PUID` (container only): The user ID to assign to the user inside the container.
+* `PGID` (container only): The group ID to assign to the user's group inside the container.
 
 ### Use
 

--- a/docker/scripts/docker-entrypoint.sh
+++ b/docker/scripts/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+groupmod -o -g "$PGID" yarrbot
+usermod -o -u "$PUID" yarrbot
+
+if [ "$1" = 'yarrbot' ]; then
+    exec gosu yarrbot "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
- With the Yarrbot container image, one can now set the UID and/or GID of the user and the user's group in the container.
- Switch to the slim Debian image as the base image for the final Yarrbot container image.
- Resolve a warning.